### PR TITLE
Correctly resolve attributes w/ external types

### DIFF
--- a/src/parser/Rule.ts
+++ b/src/parser/Rule.ts
@@ -54,8 +54,8 @@ export class Rule {
 		this.handler = handler;
 	}
 
-	addAttribute(ref: MemberRef) {
-		this.attributeTbl[ref.member.namespace.getPrefix() + ref.member.name] = ref;
+	addAttribute(ref: MemberRef, namespace: Namespace) {
+		this.attributeTbl[namespace.getPrefix() + ref.member.name] = ref;
 	}
 
 	addChild(ref: MemberRef) {

--- a/src/xml/TypeSpec.ts
+++ b/src/xml/TypeSpec.ts
@@ -173,7 +173,7 @@ export class TypeSpec extends Item {
 
 		for(spec of this.attributeSpecList) {
 			var attributeRef = MemberRef.parseSpec(spec, this.namespace);
-			if(attributeRef.member.typeSpecList) this.rule.addAttribute(attributeRef);
+			if(attributeRef.member.typeSpecList) this.rule.addAttribute(attributeRef, this.namespace);
 			this.defineMember(attributeRef);
 		}
 	}


### PR DESCRIPTION
Fixes an issue importing attributes with types from another namespace, ie.

```
<attribute name="MyAttr" type="extNS1:MyType" use="required">
```

In cases like this, we need to make sure that MyType is correctly imported and resolved.  